### PR TITLE
DTSPO-12009 - Update charts for k8s 1.25 deprecation

### DIFF
--- a/charts/jd-bureau/Chart.yaml
+++ b/charts/jd-bureau/Chart.yaml
@@ -5,5 +5,5 @@ appVersion: "2.13.6"
 description: Juror Digital - Public
 dependencies:
   - name: nodejs
-    version: 2.4.0
+    version: 2.4.11
     repository: "https://hmctspublic.azurecr.io/helm/v1/repo/"

--- a/charts/jd-bureau/Chart.yaml
+++ b/charts/jd-bureau/Chart.yaml
@@ -1,6 +1,6 @@
 name: jd-bureau
 apiVersion: v2
-version: 0.1.2
+version: 0.1.3
 appVersion: "2.13.6"
 description: Juror Digital - Public
 dependencies:

--- a/charts/jd-public/Chart.yaml
+++ b/charts/jd-public/Chart.yaml
@@ -5,5 +5,5 @@ appVersion: "2.15.129"
 description: Juror Digital - Public
 dependencies:
   - name: nodejs
-    version: 2.4.0
+    version: 2.4.11
     repository: "https://hmctspublic.azurecr.io/helm/v1/repo/"

--- a/charts/jd-public/Chart.yaml
+++ b/charts/jd-public/Chart.yaml
@@ -1,6 +1,6 @@
 name: jd-public
 apiVersion: v2
-version: 0.1.2
+version: 0.1.3
 appVersion: "2.15.129"
 description: Juror Digital - Public
 dependencies:

--- a/charts/moj-reverse-proxy/Chart.yaml
+++ b/charts/moj-reverse-proxy/Chart.yaml
@@ -5,5 +5,5 @@ appVersion: "2.15.129"
 description: Juror Digital - Public
 dependencies:
   - name: nodejs
-    version: 2.4.0
+    version: 2.4.11
     repository: "https://hmctspublic.azurecr.io/helm/v1/repo/"

--- a/charts/moj-reverse-proxy/Chart.yaml
+++ b/charts/moj-reverse-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 name: moj-reverse-proxy
 apiVersion: v2
-version: 0.1.2
+version: 0.1.3
 appVersion: "2.15.129"
 description: Juror Digital - Public
 dependencies:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-12009

### Change description ###
Update chart version and nodejs version

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
