### PR TITLE
DTSPO-12091 - Update met chart

### DIFF
--- a/charts/met/Chart.yaml
+++ b/charts/met/Chart.yaml
@@ -1,9 +1,9 @@
 name: themis-fe
 apiVersion: v2
-version: 0.1.2
+version: 0.1.3
 appVersion: "1.0.0"
 description: Themis Front End
 dependencies:
   - name: nodejs
-    version: 2.4.0
+    version: 2.4.5
     repository: "https://hmctspublic.azurecr.io/helm/v1/repo/"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-12091

### Change description ###
Update met chart to use nodejs 2.4.5 which is earliest version to support library 1.1.0
Upgrades PDb apiVersion to policy/v1 for k8s 1.25 compatibility

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
